### PR TITLE
Fix fade

### DIFF
--- a/AudioChannel.js
+++ b/AudioChannel.js
@@ -114,7 +114,7 @@ AudioChannel.prototype.playLoopSound = function (soundId, volume, pan, pitch) {
 	function playNextSound() {
 		// remove reference to current loop sound to ease optimistic garbabe collection
 		self.loopSound = null;
-		// force loading to happen at next tic in order to let garbage collector to release previous audio.
+		// force loading to happen at next tick in order to let garbage collector to release previous audio.
 		window.setTimeout(_playNextSound, 0);
 	}
 

--- a/AudioChannel.js
+++ b/AudioChannel.js
@@ -85,6 +85,8 @@ AudioChannel.prototype.playLoopSound = function (soundId, volume, pan, pitch) {
 		return;
 	}
 
+	currentSound = null;
+
 	// check if requested sound is already scheduled to play next
 	if (this.nextLoop && this.nextLoop.id === soundId) return;
 
@@ -95,6 +97,7 @@ AudioChannel.prototype.playLoopSound = function (soundId, volume, pan, pitch) {
 		if (sound.stopping) return; // callback is already scheduled
 		sound.stop(function () {
 			audioManager.freeSound(sound); // TODO: add an option to keep file in memory
+			sound = null;
 			return cb && cb();
 		});
 	}
@@ -109,8 +112,8 @@ AudioChannel.prototype.playLoopSound = function (soundId, volume, pan, pitch) {
 	}
 
 	function playNextSound() {
-		// force loading to happend in a new thread in order to let Garbage Collector to release previous audio.
-		window.setTimeout(_playNextSound, 10);
+		// force loading to happen at next tic in order to let Garbage Collector to release previous audio.
+		window.setTimeout(_playNextSound, 0);
 	}
 
 	if (crossFading) {
@@ -122,6 +125,7 @@ AudioChannel.prototype.playLoopSound = function (soundId, volume, pan, pitch) {
 		this.nextLoop.load(function onSoundLoad(error) {
 			if (error) return;
 			stopCurrentLoop(this.loopSound);
+			this.loopSound = null;
 			playNextSound();
 		});
 

--- a/AudioChannel.js
+++ b/AudioChannel.js
@@ -112,7 +112,9 @@ AudioChannel.prototype.playLoopSound = function (soundId, volume, pan, pitch) {
 	}
 
 	function playNextSound() {
-		// force loading to happen at next tic in order to let Garbage Collector to release previous audio.
+		// remove reference to current loop sound to ease optimistic garbabe collection
+		self.loopSound = null;
+		// force loading to happen at next tic in order to let garbage collector to release previous audio.
 		window.setTimeout(_playNextSound, 0);
 	}
 
@@ -125,7 +127,6 @@ AudioChannel.prototype.playLoopSound = function (soundId, volume, pan, pitch) {
 		this.nextLoop.load(function onSoundLoad(error) {
 			if (error) return;
 			stopCurrentLoop(this.loopSound);
-			this.loopSound = null;
 			playNextSound();
 		});
 

--- a/AudioChannel.js
+++ b/AudioChannel.js
@@ -99,13 +99,18 @@ AudioChannel.prototype.playLoopSound = function (soundId, volume, pan, pitch) {
 		});
 	}
 
-	function playNextSound() {
+	function _playNextSound() {
 		var sound = self.loopSound = self.nextLoop;
 		self.nextLoop = null;
 		if (!sound) return;
 		sound.setLoop(true);
 		sound.fade = defaultFade;
 		sound.play(volume * self.volume, pan, pitch); // load and play
+	}
+
+	function playNextSound() {
+		// force loading to happend in a new thread in order to let Garbage Collector to release previous audio.
+		window.setTimeout(_playNextSound, 10);
 	}
 
 	if (crossFading) {

--- a/SoundBuffered.js
+++ b/SoundBuffered.js
@@ -122,7 +122,6 @@ SoundBuffered.prototype.setVolume = function (value) {
 		this.gain.value = value;
 		return;
 	}
-	// this.gain.setTargetAtTime(value, this.audioContext.currentTime, this.fade);
 	if (value <= 0) value = MIN_VALUE;
 	var currentTime = this.audioContext.currentTime;
 	this.gain.cancelScheduledValues(currentTime);
@@ -172,7 +171,6 @@ SoundBuffered.prototype._setPlaybackRate = function (portamento) {
 		this.source.playbackRate.value = rate;
 		return;
 	}
-	// this.source.playbackRate.setTargetAtTime(rate, this.audioContext.currentTime, portamento);
 	var currentTime = this.audioContext.currentTime;
 	this.source.playbackRate.cancelScheduledValues(currentTime);
 	this.source.playbackRate.setValueAtTime(this.source.playbackRate.value || MIN_VALUE, currentTime);
@@ -347,7 +345,6 @@ SoundBuffered.prototype._stopAndClear = function () {
  * @param {Function} [cb] - optional callback function
  */
 SoundBuffered.prototype.stop = function (cb) {
-	//var fadeOutRatio = this.audioManager.settings.fadeOutRatio;
 	if (!this.playing && !this.stopping) return cb && cb();
 	this._playTriggered = 0;
 	this.stopping = true;

--- a/SoundBuffered.js
+++ b/SoundBuffered.js
@@ -124,7 +124,7 @@ SoundBuffered.prototype.setVolume = function (value) {
 	}
 	// this.gain.setTargetAtTime(value, this.audioContext.currentTime, this.fade);
 	if (value <= 0) value = MIN_VALUE;
-	var currentTime = this.audioContext.currentTime
+	var currentTime = this.audioContext.currentTime;
 	this.gain.cancelScheduledValues(currentTime);
 	this.gain.setValueAtTime(this.gain.value || MIN_VALUE, currentTime);
 	this.gain.linearRampToValueAtTime(value, currentTime + this.fade);

--- a/component.json
+++ b/component.json
@@ -1,7 +1,7 @@
 {
 	"name": "AudioManager",
 	"repo": "Wizcorp/AudioManager",
-	"version": "0.1.7",
+	"version": "0.1.8",
 	"description": "Play sounds using Web Audio, fallback to HTML5 Audio",
 	"dependencies": {
 		"Wizcorp/util": "0.1.0"

--- a/index.js
+++ b/index.js
@@ -41,7 +41,6 @@ function AudioManager(channels) {
 		maxUsedMemory:  300,  // seconds
 		defaultFade:    2,    // seconds
 		maxPlayLatency: 1000, // milliseconds
-		fadeOutRatio:   0.4,
 		crossFading:    false,
 		getFileUri:     function getFileUri(audioPath, id) { return audioPath + id + '.mp3'; }
 	};


### PR DESCRIPTION
 - `AudioParam.setTargetAtTime` was broken on Chrome. This function throw an error if param is less or equal to 0. We define a minimum constant to replace 0 when needed.
 - Fade system is skipped when unused.
 - We force the loading of looped sound to occur in a different thread to let garbage collector releasing the previous playing looped sound. This should help to avoid memory usage spikes when switching musics.

resolve #16